### PR TITLE
Change Default Adaptive Icon

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -91,5 +91,8 @@
     <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
     <bool name="config_dozeAfterScreenOff">true</bool>
     <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    
+    <!-- Specifies the path that is used by AdaptiveIconDrawable class to crop launcher icons. -->
+    <string name="config_icon_mask" translatable="false">"M50 0C77.6 0 100 22.4 100 50C100 77.6 77.6 100 50 100C22.4 100 0 77.6 0 50C0 22.4 22.4 0 50 0Z"</string>
 
 </resources>


### PR DESCRIPTION
Change Default Adaptive Icon to match Pixel. This way when selecting system default icon shape in pixel launcher, it will show round icons with masking.

Please remove useRoundIcon from vendor_gapps/overlay/framework../
We dont need this switch anymore, cause they are for legacy. Now is the time for adaptive icons.